### PR TITLE
Maven job resolver

### DIFF
--- a/mist.sbt
+++ b/mist.sbt
@@ -50,7 +50,10 @@ libraryDependencies ++= Seq(
   "org.scalamock" %% "scalamock-scalatest-support" % "3.2.2" % "test",
   "org.mapdb" % "mapdb" % "3.0.2",
   "org.eclipse.paho" % "org.eclipse.paho.client.mqttv3" % "1.1.0",
-  "org.apache.hadoop" % "hadoop-client" % "2.7.3" intransitive()
+  "org.apache.hadoop" % "hadoop-client" % "2.7.3" intransitive(),
+
+  "org.scalaj" %% "scalaj-http" % "2.3.0"
+
 )
 
 dependencyOverrides += "com.typesafe" % "config" % "1.3.1"

--- a/src/main/scala/io/hydrosphere/mist/jobs/JobFile.scala
+++ b/src/main/scala/io/hydrosphere/mist/jobs/JobFile.scala
@@ -26,6 +26,8 @@ object JobFile {
   def apply(path: String): JobFile = {
     if (path.startsWith("hdfs://")) {
       new HDFSJobFile(path)
+    } else if(path.startsWith("mvn://")) {
+      MavenArtifactResolver.fromPath(path)
     } else {
       new LocalJobFile(path)
     }
@@ -35,7 +37,9 @@ object JobFile {
     path.split('.').drop(1).lastOption.getOrElse("") match {
       case "jar" => JobFile.FileType.Jar
       case "py" => JobFile.FileType.Python
-      case _ => throw new UnknownTypeException(s"Unknown file type in $path")
+      //TODO: for maven arifact we dont have ".jar" postfix in path defenition
+      case _ =>  JobFile.FileType.Jar
+      //case _ => throw new UnknownTypeException(s"Unknown file type in $path")
     }
   }
 

--- a/src/main/scala/io/hydrosphere/mist/jobs/JobFile.scala
+++ b/src/main/scala/io/hydrosphere/mist/jobs/JobFile.scala
@@ -33,14 +33,13 @@ object JobFile {
     }
   }
 
-  def fileType(path: String): FileType = {
-    path.split('.').drop(1).lastOption.getOrElse("") match {
-      case "jar" => JobFile.FileType.Jar
-      case "py" => JobFile.FileType.Python
-      //TODO: for maven arifact we dont have ".jar" postfix in path defenition
-      case _ =>  JobFile.FileType.Jar
-      //case _ => throw new UnknownTypeException(s"Unknown file type in $path")
-    }
+  def fileType(path: String): FileType = path match {
+    case p if p.startsWith("mvn://") || p.endsWith(".jar") =>
+      JobFile.FileType.Jar
+    case p if p.endsWith(".py") =>
+      JobFile.FileType.Python
+    case _ =>
+      throw new UnknownTypeException(s"Unknown file type in $path")
   }
 
 }

--- a/src/main/scala/io/hydrosphere/mist/jobs/MavenArtifactResolver.scala
+++ b/src/main/scala/io/hydrosphere/mist/jobs/MavenArtifactResolver.scala
@@ -9,7 +9,8 @@ import java.nio.file.{Files, Paths}
   */
 case class MavenArtifactResolver(
   repoUrl: String,
-  artifact: MavenArtifact
+  artifact: MavenArtifact,
+  targetDirectory: String = "/tmp"
 ) extends JobFile {
 
   import scalaj.http._
@@ -30,13 +31,14 @@ case class MavenArtifactResolver(
       println(message)
       throw new JobFile.NotFoundException(message)
     } else {
-      val localPath = Paths.get("/tmp", artifact.jarName)
+      val localPath = Paths.get(targetDirectory, artifact.jarName)
       Files.write(localPath, resp.body)
       localPath.toFile
     }
   }
 
-  private def jarUlr: String = s"$repoUrl/${artifact.jarPath}"
+  private def jarUlr: String =
+    s"$repoUrl/${artifact.jarPath}".replaceAll("(?<!http:|https:)//", "/")
 
 }
 

--- a/src/main/scala/io/hydrosphere/mist/jobs/MavenArtifactResolver.scala
+++ b/src/main/scala/io/hydrosphere/mist/jobs/MavenArtifactResolver.scala
@@ -3,6 +3,10 @@ package io.hydrosphere.mist.jobs
 import java.io.File
 import java.nio.file.{Files, Paths}
 
+/**
+  * Maven-like artifact resolver
+  * Currently it can download only ONE root jar
+  */
 case class MavenArtifactResolver(
   repoUrl: String,
   artifact: MavenArtifact
@@ -39,6 +43,10 @@ case class MavenArtifactResolver(
 object MavenArtifactResolver {
   import scala.util.matching.Regex
 
+  /**
+    * Pattern for catching job file definition ib routes conf
+    * Example: "mvn://http://repo1.maven.org/maven2 :: org.company % name % version"
+    */
   val pattern = "mvn://" +
     "(https?://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|])\\s?::\\s?" + // repo - host:port/path
     "(.+) % (.+) % (.+)"r

--- a/src/main/scala/io/hydrosphere/mist/jobs/MavenArtifactResolver.scala
+++ b/src/main/scala/io/hydrosphere/mist/jobs/MavenArtifactResolver.scala
@@ -1,0 +1,81 @@
+package io.hydrosphere.mist.jobs
+
+import java.io.File
+import java.nio.file.{Files, Paths}
+
+case class MavenArtifactResolver(
+  repoUrl: String,
+  artifact: MavenArtifact
+) extends JobFile {
+
+  import scalaj.http._
+
+  override def exists: Boolean = {
+    val resp = Http(jarUlr).method("HEAD").asString
+    resp.code == 200
+  }
+
+  override def file: File = {
+    val resp = Http(jarUlr).method("GET").asBytes
+    if (resp.code != 200) {
+      val message =
+        s"""
+           |Could not find $jarUlr.
+           | Response code: ${resp.code} ${new String(resp.body)}
+         """.stripMargin
+      println(message)
+      throw new JobFile.NotFoundException(message)
+    } else {
+      val localPath = Paths.get("/tmp", artifact.jarName)
+      Files.write(localPath, resp.body)
+      localPath.toFile
+    }
+  }
+
+  private def jarUlr: String = s"$repoUrl/${artifact.jarPath}"
+
+}
+
+object MavenArtifactResolver {
+  import scala.util.matching.Regex
+
+  val pattern = "mvn://" +
+    "(https?://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|])\\s?::\\s?" + // repo - host:port/path
+    "(.+) % (.+) % (.+)"r
+
+  def fromPath(p: String): MavenArtifactResolver = pattern.findFirstMatchIn(p) match {
+    case Some(m) => toResolver(m)
+    case None =>
+      val message =
+        s"""Invalid path $p for maven artifact resolver.
+           |String should be like: \"mvn://host:port/myrepo:: org % name % version\" """.stripMargin
+      throw new IllegalArgumentException(message)
+  }
+
+  private def toResolver(m: Regex.Match): MavenArtifactResolver = {
+    val groups = m.subgroups
+
+    val repoUrl = groups(0)
+    val artifact = MavenArtifact(groups(1), groups(2), groups(3))
+    new MavenArtifactResolver(repoUrl, artifact)
+  }
+}
+
+case class MavenArtifact(
+  organization: String,
+  name: String,
+  version: String
+) {
+
+  def jarPath: String = {
+    val org = organization.split('.').toList
+    val last = List(
+      name,
+      version,
+      jarName
+    )
+    (org ++ last).mkString("/")
+  }
+
+  def jarName: String = s"$name-$version.jar"
+}

--- a/src/main/scala/io/hydrosphere/mist/master/ClusterManager.scala
+++ b/src/main/scala/io/hydrosphere/mist/master/ClusterManager.scala
@@ -9,6 +9,7 @@ import akka.pattern.ask
 import com.typesafe.config.ConfigFactory
 import io.hydrosphere.mist.Messages._
 import io.hydrosphere.mist.jobs._
+import io.hydrosphere.mist.jobs.runners.Runner
 import io.hydrosphere.mist.utils.{Collections, ExternalJar, ExternalMethodArgument, Logger}
 import io.hydrosphere.mist.worker.{JobDescriptionSerializable, LocalNode, WorkerDescription}
 import io.hydrosphere.mist.{Constants, MistConfig, Worker}

--- a/src/test/scala/io/hydrosphere/mist/jobs/JobFileTest.scala
+++ b/src/test/scala/io/hydrosphere/mist/jobs/JobFileTest.scala
@@ -1,0 +1,18 @@
+package io.hydrosphere.mist.jobs
+
+import org.scalatest.{FunSuite, Matchers}
+
+class JobFileTest extends FunSuite with Matchers {
+
+  test("file type matching by type") {
+    import JobFile._
+
+    fileType("erer/yoyo.py") shouldBe FileType.Python
+    fileType("erer/yoyo.jar") shouldBe FileType.Jar
+    fileType("mvn://http://host/:: org % name % 0.0.1") shouldBe FileType.Jar
+
+    intercept[Throwable] {
+      fileType("abyrvalg")
+    }
+  }
+}

--- a/src/test/scala/io/hydrosphere/mist/jobs/MavenArtifactResolverTest.scala
+++ b/src/test/scala/io/hydrosphere/mist/jobs/MavenArtifactResolverTest.scala
@@ -1,0 +1,92 @@
+package io.hydrosphere.mist.jobs
+
+import java.nio.file.{Files, Paths}
+
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import akka.stream.scaladsl.Flow
+import org.scalatest.{FunSuite, Matchers}
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future, Promise}
+
+class MavenArtifactResolverTest extends FunSuite with Matchers {
+
+  test("maven artifact") {
+    val remote = MavenArtifact("io.hydrosphere", "mist", "0.0.1")
+    remote.jarName shouldBe "mist-0.0.1.jar"
+    remote.jarPath shouldBe "io/hydrosphere/mist/0.0.1/mist-0.0.1.jar"
+  }
+
+  test("construct resolver from path") {
+    val path = "mvn://http://localhost:8081/artifactory/releases :: io.hydrosphere % mist_2.10 % 0.0.1"
+    val resolver = MavenArtifactResolver.fromPath(path)
+    resolver.repoUrl shouldBe "http://localhost:8081/artifactory/releases"
+    resolver.artifact shouldBe MavenArtifact("io.hydrosphere", "mist_2.10", "0.0.1")
+  }
+
+  test("resolver over http") {
+    import akka.http.scaladsl.model.StatusCodes._
+
+    val routes = Flow[HttpRequest].map { request =>
+      if (request.uri.toString().endsWith(".jar")) {
+        HttpResponse(status = OK, entity = "JAR CONTENT")
+      } else {
+        HttpResponse(status = NotFound, entity = s"Not found ${request.uri}")
+      }
+    }
+
+    val future = MockHttpServer.onServer(routes, binding => {
+      val port = binding.localAddress.getPort
+      val path = s"mvn://http://localhost:$port/artifactory/libs-release-local :: mist_examples % mist_examples_2.10 % 0.8.0"
+      val resolver = MavenArtifactResolver.fromPath(path)
+      resolver.file
+    })
+
+    val file = Await.result(future, Duration.Inf)
+    file.exists() shouldBe true
+    val content = Files.readAllBytes(Paths.get(file.getAbsolutePath))
+    new String(content) shouldBe "JAR CONTENT"
+  }
+
+  object MockHttpServer {
+
+    import akka.actor.ActorSystem
+    import akka.http.scaladsl.Http
+    import akka.stream.ActorMaterializer
+    import akka.util.Timeout
+
+    import scala.concurrent.duration._
+
+    def onServer[A](
+      routes: Flow[HttpRequest, HttpResponse, Unit],
+      f: (Http.ServerBinding) => A): Future[A] = {
+
+      implicit val system = ActorSystem("mock-http-cli")
+      implicit val materializer = ActorMaterializer()
+
+      implicit val executionContext = system.dispatcher
+      implicit val timeout = Timeout(1.seconds)
+
+      val binding = Http().bindAndHandle(routes, "localhost", 0)
+
+      val close = Promise[Http.ServerBinding]
+      close.future
+        .flatMap(binding => binding.unbind())
+        .onComplete(_ => system.terminate())
+
+      val result = binding.flatMap(binding => {
+        try{
+          Future.successful(f(binding))
+        } catch {
+          case e: Throwable =>
+            Future.failed(e)
+        } finally {
+          close.success(binding)
+        }
+      })
+      result
+    }
+
+
+  }
+}

--- a/src/test/scala/io/hydrosphere/mist/jobs/MavenArtifactResolverTest.scala
+++ b/src/test/scala/io/hydrosphere/mist/jobs/MavenArtifactResolverTest.scala
@@ -38,8 +38,9 @@ class MavenArtifactResolverTest extends FunSuite with Matchers {
 
     val future = MockHttpServer.onServer(routes, binding => {
       val port = binding.localAddress.getPort
-      val path = s"mvn://http://localhost:$port/artifactory/libs-release-local :: mist_examples % mist_examples_2.10 % 0.8.0"
-      val resolver = MavenArtifactResolver.fromPath(path)
+      val url = s"http://localhost:$port/artifactory/libs-release-local"
+      val artefact = MavenArtifact("mist_examples", "mist_examples_2.10", "0.8.0")
+      val resolver = MavenArtifactResolver(url, artefact, "target")
       resolver.file
     })
 

--- a/src/test/scala/io/hydrosphere/mist/jobs/MavenArtifactResolverTest.scala
+++ b/src/test/scala/io/hydrosphere/mist/jobs/MavenArtifactResolverTest.scala
@@ -39,8 +39,8 @@ class MavenArtifactResolverTest extends FunSuite with Matchers {
     val future = MockHttpServer.onServer(routes, binding => {
       val port = binding.localAddress.getPort
       val url = s"http://localhost:$port/artifactory/libs-release-local"
-      val artefact = MavenArtifact("mist_examples", "mist_examples_2.10", "0.8.0")
-      val resolver = MavenArtifactResolver(url, artefact, "target")
+      val artifact = MavenArtifact("mist_examples", "mist_examples_2.10", "0.8.0")
+      val resolver = MavenArtifactResolver(url, artifact, "target")
       resolver.file
     })
 

--- a/src/test/scala/io/hydrosphere/mist/jobs/MavenArtifactResolverTest.scala
+++ b/src/test/scala/io/hydrosphere/mist/jobs/MavenArtifactResolverTest.scala
@@ -79,7 +79,10 @@ class MavenArtifactResolverTest extends FunSuite with Matchers {
       val close = Promise[Http.ServerBinding]
       close.future
         .flatMap(binding => binding.unbind())
-        .onComplete(_ => system.terminate())
+        .onComplete(_ => {
+          system.shutdown()
+          system.awaitTermination()
+        })
 
       val result = binding.flatMap(binding => {
         try{

--- a/src/test/scala/io/hydrosphere/mist/jobs/MavenArtifactResolverTest.scala
+++ b/src/test/scala/io/hydrosphere/mist/jobs/MavenArtifactResolverTest.scala
@@ -27,6 +27,7 @@ class MavenArtifactResolverTest extends FunSuite with Matchers {
   test("resolver over http") {
     import akka.http.scaladsl.model.StatusCodes._
 
+    // maven-like repository mock
     val routes = Flow[HttpRequest].map { request =>
       if (request.uri.toString().endsWith(".jar")) {
         HttpResponse(status = OK, entity = "JAR CONTENT")

--- a/src/test/scala/io/hydrosphere/mist/jobs/MavenArtifactResolverTest.scala
+++ b/src/test/scala/io/hydrosphere/mist/jobs/MavenArtifactResolverTest.scala
@@ -25,12 +25,6 @@ class MavenArtifactResolverTest extends FunSuite with Matchers {
     resolver.artifact shouldBe MavenArtifact("io.hydrosphere", "mist_2.10", "0.0.1")
   }
 
-  test("construct resolver from path232323") {
-    val path = "mvn://http://localhost:8081/artifactory/libs-release-local :: mist_examples % mist_examples_2.10 % 0.8.0"
-    val resolver = MavenArtifactResolver.fromPath(path)
-    resolver.file
-  }
-
   test("resolver over http") {
     import akka.http.scaladsl.model.StatusCodes._
 


### PR DESCRIPTION
It's initial implementation for #142.
With that kind of resolver it's possible to pull jar from maven-like repository.
Router config example:
```
simple-context = {
  path = "mvn://http://myrepo:port/repopath :: io.hydrosphere % mist_2.10 % 0.0.1"
  className = "SimpleContext$"
  namespace = "foo"
}

```

Currently it's support only root jar downloading.
I'm not sure how should mist or spark works if user provide artifact with dependencies. If it's common case for "spark-folks", it's require some changes of JarRunner, and maybe separated from jobs repository configuration (in case when dependency is published in maven central as example)

There is problem with `ClusterManger` and mist-jobs, that have no life-cycle.`ClusterManager` downloading remote files on every routes request. It also doing dirty `job-info` building by job `path` definition
I think there is need some `routes-holder`, which can pull / cache / check existence / provide info of jobs.

