### PR TITLE
Shade scopt.244

### DIFF
--- a/mist.sbt
+++ b/mist.sbt
@@ -1,6 +1,6 @@
 import sbt.Keys._
-import sbtassembly.Plugin.AssemblyKeys._
 import StageDist._
+import sbtassembly.AssemblyPlugin.autoImport._
 
 resolvers ++= Seq(
   Resolver.sonatypeRepo("releases"),
@@ -51,7 +51,6 @@ lazy val libraryAdditionalDependencies = currentSparkVersion match {
 }
 
 lazy val mistLib = project.in(file("mist-lib"))
-  .settings(assemblySettings)
   .settings(commonSettings: _*)
   .settings(PublishSettings.settings: _*)
   .settings(
@@ -76,7 +75,6 @@ lazy val currentExamples = currentSparkVersion match {
 lazy val mist = project.in(file("."))
   .dependsOn(mistLib)
   .enablePlugins(DockerPlugin)
-  .settings(assemblySettings)
   .settings(commonSettings: _*)
   .configs(IntegrationTest)
   .settings(Defaults.itSettings: _*)
@@ -334,5 +332,8 @@ lazy val commonAssemblySettings = Seq(
     case _ => MergeStrategy.first
   }
   },
+  assemblyShadeRules in assembly := Seq(
+      ShadeRule.rename("scopt.**" -> "shaded.@0").inAll
+  ),
   test in assembly := {}
 )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,3 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.10.2")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.1.0")
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
@@ -6,5 +5,5 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M15")
 addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.4.1")
-
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
 libraryDependencies += "org.apache.commons" % "commons-compress" % "1.8"


### PR DESCRIPTION
#244 Update sbt-assembly version for accessing shading feature and add rule of shade scopt library that is conflicted when job submitting to mist.

This is blind fix because there is no reproducible scenario, but everything works as expected in ordinary usage. According to [scopt/scopt#103](https://github.com/scopt/scopt/issues/103) shading must fix this issue. 