### PR TITLE
dev run api

### DIFF
--- a/src/main/scala/io/hydrosphere/mist/jobs/JobResult.scala
+++ b/src/main/scala/io/hydrosphere/mist/jobs/JobResult.scala
@@ -1,6 +1,6 @@
 package io.hydrosphere.mist.jobs
 
-import io.hydrosphere.mist.master.models.JobStartRequest
+import io.hydrosphere.mist.master.models.EndpointStartRequest
 import io.hydrosphere.mist.utils.TypeAlias.JobResponse
 
 /** Used for packing results for response
@@ -8,32 +8,28 @@ import io.hydrosphere.mist.utils.TypeAlias.JobResponse
   * @param success boolean flag of success
   * @param payload job results
   * @param errors possible error list
-  * @param request user request
   */
 case class JobResult(
   success: Boolean,
   payload: JobResponse,
-  errors: List[String],
-  request: JobStartRequest)
+  errors: List[String])
 
 object JobResult {
 
-  def success(payload: JobResponse, request: JobStartRequest): JobResult = {
+  def success(payload: JobResponse): JobResult = {
     JobResult(
       success = true,
       payload = payload,
-      errors = List.empty,
-      request = request)
+      errors = List.empty)
   }
 
-  def failure(errors: List[String], request: JobStartRequest): JobResult = {
+  def failure(errors: List[String]): JobResult = {
     JobResult(
       success = false,
       payload = Map.empty,
-      errors = errors,
-      request = request)
+      errors = errors)
   }
 
-  def failure(error: String, request: JobStartRequest): JobResult =
-    failure(List(error), request)
+  def failure(error: String): JobResult =
+    failure(List(error))
 }

--- a/src/main/scala/io/hydrosphere/mist/master/JobService.scala
+++ b/src/main/scala/io/hydrosphere/mist/master/JobService.scala
@@ -8,7 +8,7 @@ import io.hydrosphere.mist.Messages.StatusMessages
 import io.hydrosphere.mist.Messages.StatusMessages.{FailedEvent, Register}
 import io.hydrosphere.mist.Messages.WorkerMessages._
 import io.hydrosphere.mist.jobs._
-import io.hydrosphere.mist.master.models.{ContextConfig, RunMode, EndpointConfig, RunSettings}
+import io.hydrosphere.mist.master.models._
 
 import scala.concurrent.Future
 import scala.reflect.ClassTag
@@ -47,16 +47,8 @@ class JobService(workerManager: ActorRef, statusService: ActorRef) {
 
   def stopWorker(workerId: String): Future[Unit] = workerManager.ask(StopWorker(workerId)).map(_ => ())
 
-  def startJob(
-    id: String,
-    endpoint: EndpointConfig,
-    context: ContextConfig,
-    parameters: Map[String, Any],
-    runMode: RunMode,
-    source: JobDetails.Source,
-    externalId: Option[String],
-    action: Action = Action.Execute
-  ): Future[ExecutionInfo] = {
+  def startJob(req: JobStartRequest): Future[ExecutionInfo] = {
+    import req._
 
     val internalRequest = RunJobRequest(
       id = id,

--- a/src/main/scala/io/hydrosphere/mist/master/Master.scala
+++ b/src/main/scala/io/hydrosphere/mist/master/Master.scala
@@ -118,7 +118,7 @@ object Master extends App with Logger {
         // api router can't chain unhandled calls, because it's wrapped in cors directive
         ws.route ~ api
       }
-      val http = new HttpUi(config.http.uiPath).route ~ api.route ~ apiv2
+      val http = new HttpUi(config.http.uiPath).route ~ api.route ~ DevApi.devRoutes(masterService) ~ apiv2
       Http().bindAndHandle(http, config.http.host, config.http.port)
     }
 

--- a/src/main/scala/io/hydrosphere/mist/master/MasterService.scala
+++ b/src/main/scala/io/hydrosphere/mist/master/MasterService.scala
@@ -1,5 +1,7 @@
 package io.hydrosphere.mist.master
 
+import java.util.UUID
+
 import cats.data._
 import cats.implicits._
 import io.hydrosphere.mist.jobs.JobDetails.Source.Async
@@ -21,21 +23,21 @@ class MasterService(
   val logStorageMappings: LogStorageMappings
 ) extends Logger {
 
-  def runJob(req: JobStartRequest, source: JobDetails.Source): Future[Option[JobStartResponse]] = {
+  def runJob(req: EndpointStartRequest, source: JobDetails.Source): Future[Option[JobStartResponse]] = {
     val out = for {
       executionInfo <- OptionT(runJobRaw(req, source))
     } yield JobStartResponse(executionInfo.request.id)
     out.value
   }
 
-  def forceJobRun(req: JobStartRequest, source: JobDetails.Source, action: Action = Action.Execute): Future[Option[JobResult]] = {
+  def forceJobRun(req: EndpointStartRequest, source: JobDetails.Source, action: Action = Action.Execute): Future[Option[JobResult]] = {
     val promise = Promise[Option[JobResult]]
     runJobRaw(req, source, action).map({
       case Some(info) => info.promise.future.onComplete {
         case Success(r) =>
-          promise.success(Some(JobResult.success(r, req)))
+          promise.success(Some(JobResult.success(r)))
         case Failure(e) =>
-          promise.success(Some(JobResult.failure(e.getMessage, req)))
+          promise.success(Some(JobResult.failure(e.getMessage)))
       }
       case None => promise.success(None)
     })
@@ -43,10 +45,44 @@ class MasterService(
     promise.future
   }
 
+  def devRun(
+    req: DevJobStartRequest,
+    source: JobDetails.Source,
+    action: Action = Action.Execute
+  ): Future[ExecutionInfo] = {
+
+    val eC = EndpointConfig(
+      name = req.fakeName,
+      path = req.path,
+      className = req.className,
+      defaultContext = req.context
+    )
+
+    val f = loadEndpointInfo(eC) match {
+      case Success(fullInfo) => validate(fullInfo.info, req.parameters, action)
+      case Failure(e) => Future.failed(e)
+    }
+
+    for {
+      _             <- f
+      context       <- contexts.getOrDefault(req.context)
+      executionInfo <- jobService.startJob(JobStartRequest(
+        id = UUID.randomUUID().toString,
+        endpoint = eC,
+        context = context,
+        parameters = req.parameters,
+        runMode = RunMode.Shared,
+        source = source,
+        externalId = req.externalId,
+        action = action
+      ))
+    } yield executionInfo
+  }
+
   def recoverJobs(): Future[Unit] = {
 
     def restartJob(job: JobDetails): Future[Unit] = {
-      val req = JobStartRequest(job.endpoint, job.params.arguments, job.externalId, id = job.jobId)
+      val req = EndpointStartRequest(job.endpoint, job.params.arguments, job.externalId, id = job.jobId)
       runJob(req, job.source).map(_ => ())
     }
 
@@ -68,31 +104,32 @@ class MasterService(
   }
 
   private def runJobRaw(
-    req: JobStartRequest,
+    req: EndpointStartRequest,
     source: JobDetails.Source,
     action: Action = Action.Execute): Future[Option[ExecutionInfo]] = {
     val out = for {
       fullInfo       <- OptionT(endpoints.getFullInfo(req.endpointId))
-      endpoint       = fullInfo.config
-      jobInfo        = fullInfo.info
+      endpoint       =  fullInfo.config
+      jobInfo        =  fullInfo.info
       _              <- OptionT.liftF(validate(jobInfo, req.parameters, action))
       context        <- OptionT.liftF(selectContext(req, endpoint))
-      executionInfo  <- OptionT.liftF(jobService.startJob(
-        req.id,
-        endpoint,
-        context,
-        req.parameters,
-        req.runSettings.mode,
-        source,
-        req.externalId,
-        action
-      ))
+      jobStartReq    = JobStartRequest(
+        id = req.id,
+        endpoint = endpoint,
+        context = context,
+        parameters = req.parameters,
+        runMode = req.runSettings.mode,
+        source = source,
+        externalId = req.externalId,
+        action = action
+      )
+      executionInfo  <- OptionT.liftF(jobService.startJob(jobStartReq))
     } yield executionInfo
 
     out.value
   }
 
-  private def selectContext(req: JobStartRequest, endpoint: EndpointConfig): Future[ContextConfig] = {
+  private def selectContext(req: EndpointStartRequest, endpoint: EndpointConfig): Future[ContextConfig] = {
     val name = req.runSettings.contextId.getOrElse(endpoint.defaultContext)
     contexts.getOrDefault(name)
   }

--- a/src/main/scala/io/hydrosphere/mist/master/interfaces/async/AsyncInterface.scala
+++ b/src/main/scala/io/hydrosphere/mist/master/interfaces/async/AsyncInterface.scala
@@ -22,7 +22,7 @@ class AsyncInterface(
   private def process(message: String): Unit = {
     try {
       val json = message.parseJson
-      val request = json.convertTo[AsyncJobStartRequest]
+      val request = json.convertTo[AsyncEndpointStartRequest]
       masterService.runJob(request.toCommon, source)
     } catch {
       case e: DeserializationException =>

--- a/src/main/scala/io/hydrosphere/mist/master/interfaces/async/AsyncInterface.scala
+++ b/src/main/scala/io/hydrosphere/mist/master/interfaces/async/AsyncInterface.scala
@@ -5,8 +5,10 @@ import io.hydrosphere.mist.master.MasterService
 import io.hydrosphere.mist.master.interfaces.JsonCodecs
 import io.hydrosphere.mist.master.models._
 import io.hydrosphere.mist.utils.Logger
-import spray.json.{DeserializationException, JsonParser, pimpString}
+import spray.json.{JsValue, DeserializationException, JsonParser, pimpString}
 import JsonCodecs._
+
+import scala.util.{Failure, Success, Try}
 
 class AsyncInterface(
   masterService: MasterService,
@@ -20,10 +22,20 @@ class AsyncInterface(
   }
 
   private def process(message: String): Unit = {
+    def asEndpointRequest(js: JsValue) = js.convertTo[AsyncEndpointStartRequest]
+    def asDevRequest(js: JsValue) = js.convertTo[DevJobStartRequestModel]
+
     try {
-      val json = message.parseJson
-      val request = json.convertTo[AsyncEndpointStartRequest]
-      masterService.runJob(request.toCommon, source)
+      val js = message.parseJson
+
+      Try[Any](asDevRequest(js)).orElse(Try(asEndpointRequest(js))) match {
+        case Success(req: AsyncEndpointStartRequest) =>
+          masterService.runJob(req.toCommon, source)
+        case Success(req: DevJobStartRequestModel) =>
+          masterService.devRun(req.toCommon, source)
+        case Success(x) => throw new IllegalArgumentException("Unknown request type")
+        case Failure(e) => throw e
+      }
     } catch {
       case e: DeserializationException =>
         logger.warn(s"Message $message does not conform with start request")
@@ -33,6 +45,7 @@ class AsyncInterface(
         logger.error(s"Error occurred during handling message $message", e)
     }
   }
+
 
   def close(): Unit = input.close()
 

--- a/src/main/scala/io/hydrosphere/mist/master/interfaces/cli/CliResponder.scala
+++ b/src/main/scala/io/hydrosphere/mist/master/interfaces/cli/CliResponder.scala
@@ -6,7 +6,7 @@ import akka.util.Timeout
 import io.hydrosphere.mist.Messages.{ListRoutes, RunJobCli, StatusMessages}
 import io.hydrosphere.mist.jobs.JobDetails.Source
 import io.hydrosphere.mist.master.MasterService
-import io.hydrosphere.mist.master.models.JobStartRequest
+import io.hydrosphere.mist.master.models.EndpointStartRequest
 import io.hydrosphere.mist.utils.Logger
 
 import scala.concurrent.duration._
@@ -27,7 +27,7 @@ class CliResponder(
       masterService.endpointsInfo.pipeTo(sender())
 
     case r: RunJobCli =>
-      val req = JobStartRequest(r.endpointId, r.params, r.extId)
+      val req = EndpointStartRequest(r.endpointId, r.params, r.extId)
       masterService.runJob(req, Source.Cli).pipeTo(sender())
 
     case StatusMessages.RunningJobs =>

--- a/src/main/scala/io/hydrosphere/mist/master/interfaces/http/DevApi.scala
+++ b/src/main/scala/io/hydrosphere/mist/master/interfaces/http/DevApi.scala
@@ -1,0 +1,39 @@
+package io.hydrosphere.mist.master.interfaces.http
+
+import akka.http.scaladsl.marshalling
+import akka.http.scaladsl.model
+import akka.http.scaladsl.server.Directives
+import akka.http.scaladsl.server.directives.ParameterDirectives
+import io.hydrosphere.mist.jobs.JobDetails.Source
+
+import io.hydrosphere.mist.master.MasterService
+import io.hydrosphere.mist.master.interfaces.JsonCodecs
+import io.hydrosphere.mist.master.models.DevJobStartRequestModel
+
+/**
+  * Warning! - it is not part of public api!
+  *
+  */
+object DevApi {
+
+  import Directives._
+  import JsonCodecs._
+  import ParameterDirectives.ParamMagnet
+  import akka.http.scaladsl.server._
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  def devRoutes(masterService: MasterService): Route = {
+    path( "v2" / "hidden" / "devrun" ) {
+      post( parameter('force ? false) { force =>
+        entity(as[DevJobStartRequestModel]) { req =>
+          val execInfo = masterService.devRun(req.toCommon, Source.Http)
+          if (force)
+            complete(execInfo.flatMap(_.toJobResult))
+          else
+            complete(execInfo.map(_.toJobStartResponse))
+        }
+      })
+    }
+  }
+}

--- a/src/main/scala/io/hydrosphere/mist/master/interfaces/http/HttpApi.scala
+++ b/src/main/scala/io/hydrosphere/mist/master/interfaces/http/HttpApi.scala
@@ -6,7 +6,7 @@ import io.hydrosphere.mist.jobs.JobDetails.Source
 import io.hydrosphere.mist.jobs._
 import io.hydrosphere.mist.master.MasterService
 import io.hydrosphere.mist.master.interfaces.JsonCodecs
-import io.hydrosphere.mist.master.models.{RunSettings, JobStartRequest}
+import io.hydrosphere.mist.master.models.{RunSettings, EndpointStartRequest}
 import io.hydrosphere.mist.utils.Logger
 import io.hydrosphere.mist.utils.TypeAlias.JobParameters
 
@@ -65,7 +65,7 @@ class HttpApi(master: MasterService) extends Logger {
               Action.Serve
             else Action.Execute
 
-            val request = JobStartRequest(
+            val request = EndpointStartRequest(
               endpointId = routeId,
               parameters = jobParams,
               externalId = None,

--- a/src/main/scala/io/hydrosphere/mist/master/interfaces/http/HttpV2Routes.scala
+++ b/src/main/scala/io/hydrosphere/mist/master/interfaces/http/HttpV2Routes.scala
@@ -10,7 +10,7 @@ import io.hydrosphere.mist.jobs.JobDetails.Source
 import io.hydrosphere.mist.master.data.ContextsStorage
 import io.hydrosphere.mist.master.{JobService, MasterService}
 import io.hydrosphere.mist.master.interfaces.JsonCodecs
-import io.hydrosphere.mist.master.models.{ContextConfig, EndpointConfig, JobStartRequest, RunMode, RunSettings}
+import io.hydrosphere.mist.master.models._
 import io.hydrosphere.mist.utils.TypeAlias.JobParameters
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -108,9 +108,9 @@ object HttpV2Base {
     routeId: String,
     queryParams: JobRunQueryParams,
     parameters: JobParameters
-  ): JobStartRequest = {
+  ): EndpointStartRequest = {
     val runSettings = queryParams.buildRunSettings()
-    JobStartRequest(routeId, parameters, queryParams.externalId, runSettings)
+    EndpointStartRequest(routeId, parameters, queryParams.externalId, runSettings)
   }
 }
 

--- a/src/main/scala/io/hydrosphere/mist/master/interfaces/jsonCodecs.scala
+++ b/src/main/scala/io/hydrosphere/mist/master/interfaces/jsonCodecs.scala
@@ -128,7 +128,7 @@ trait JsonCodecs extends SprayJsonSupport
         case RunMode.Shared => JsObject(("type", JsString("shared")))
         case RunMode.ExclusiveContext(id) =>
           JsObject(
-            ("type", JsString("uniqueContext")),
+            ("type", JsString("exclusive")),
             ("id", id.map(JsString(_)).getOrElse(JsNull))
           )
       }

--- a/src/main/scala/io/hydrosphere/mist/master/interfaces/jsonCodecs.scala
+++ b/src/main/scala/io/hydrosphere/mist/master/interfaces/jsonCodecs.scala
@@ -154,14 +154,16 @@ trait JsonCodecs extends SprayJsonSupport
 
   implicit val runSettingsF = jsonFormat2(RunSettings.apply)
 
-  implicit val jobStartRequestF = jsonFormat5(JobStartRequest)
-  implicit val asynJobStartRequestF = jsonFormat4(AsyncJobStartRequest)
+  implicit val jobStartRequestF = jsonFormat5(EndpointStartRequest)
+  implicit val asynJobStartRequestF = jsonFormat4(AsyncEndpointStartRequest)
 
   implicit val endpointConfigF = jsonFormat4(EndpointConfig.apply)
 
-  implicit val jobResultFormatF = jsonFormat4(JobResult.apply)
+  implicit val jobResultFormatF = jsonFormat3(JobResult.apply)
 
   implicit val logEventF = jsonFormat5(LogEvent.apply)
+
+  implicit val devJobStartReqModelF = jsonFormat7(DevJobStartRequestModel.apply)
 
   implicit val durationF = new JsonFormat[Duration] {
 

--- a/src/main/scala/io/hydrosphere/mist/master/models/models.scala
+++ b/src/main/scala/io/hydrosphere/mist/master/models/models.scala
@@ -2,6 +2,8 @@ package io.hydrosphere.mist.master.models
 
 import java.util.UUID
 
+import io.hydrosphere.mist.jobs.{Action, JobDetails}
+
 /** Specify how use context/workers */
 sealed trait RunMode {
 
@@ -41,12 +43,23 @@ object RunSettings {
   * Request for starting job by name
   * New version api
   */
-case class JobStartRequest(
+case class EndpointStartRequest(
   endpointId: String,
   parameters: Map[String, Any],
   externalId: Option[String] = None,
   runSettings: RunSettings = RunSettings.Default,
   id: String = UUID.randomUUID().toString
+)
+
+case class JobStartRequest(
+  id: String,
+  endpoint: EndpointConfig,
+  context: ContextConfig,
+  parameters: Map[String, Any],
+  runMode: RunMode,
+  source: JobDetails.Source,
+  externalId: Option[String],
+  action: Action = Action.Execute
 )
 
 case class JobStartResponse(id: String)
@@ -55,17 +68,52 @@ case class JobStartResponse(id: String)
   * Like JobStartRequest, but for async interfaces
   * (spray json not support default values)
   */
-case class AsyncJobStartRequest(
+case class AsyncEndpointStartRequest(
   endpointId: String,
   parameters: Option[Map[String, Any]],
   externalId: Option[String],
   runSettings: Option[RunSettings]
 ) {
 
-  def toCommon: JobStartRequest =
-    JobStartRequest(
+  def toCommon: EndpointStartRequest =
+    EndpointStartRequest(
       endpointId,
       parameters.getOrElse(Map.empty),
       externalId,
       runSettings.getOrElse(RunSettings.Default))
+}
+
+
+case class DevJobStartRequest(
+  fakeName: String,
+  path: String,
+  className: String,
+  parameters: Map[String, Any],
+  externalId: Option[String],
+
+  runSettings: RunSettings = RunSettings.Default,
+  context: String
+)
+
+case class DevJobStartRequestModel(
+  fakeName: String,
+  path: String,
+  className: String,
+  parameters: Option[Map[String, Any]],
+  externalId: Option[String],
+  runSettings: Option[RunSettings],
+  context: String
+) {
+
+  def toCommon: DevJobStartRequest = {
+    DevJobStartRequest(
+      fakeName = fakeName,
+      path = path,
+      className = className,
+      parameters = parameters.getOrElse(Map.empty),
+      externalId = externalId,
+      runSettings = runSettings.getOrElse(RunSettings.Default),
+      context = context
+    )
+  }
 }

--- a/src/main/scala/io/hydrosphere/mist/master/models/models.scala
+++ b/src/main/scala/io/hydrosphere/mist/master/models/models.scala
@@ -91,7 +91,7 @@ case class DevJobStartRequest(
   parameters: Map[String, Any],
   externalId: Option[String],
 
-  runSettings: RunSettings = RunSettings.Default,
+  runMode: RunMode,
   context: String
 )
 
@@ -101,7 +101,7 @@ case class DevJobStartRequestModel(
   className: String,
   parameters: Option[Map[String, Any]],
   externalId: Option[String],
-  runSettings: Option[RunSettings],
+  runMode: Option[RunMode],
   context: String
 ) {
 
@@ -112,7 +112,7 @@ case class DevJobStartRequestModel(
       className = className,
       parameters = parameters.getOrElse(Map.empty),
       externalId = externalId,
-      runSettings = runSettings.getOrElse(RunSettings.Default),
+      runMode = runMode.getOrElse(RunMode.Shared),
       context = context
     )
   }

--- a/src/test/scala/io/hydrosphere/mist/jobs/jar/JobInstanceSpec.scala
+++ b/src/test/scala/io/hydrosphere/mist/jobs/jar/JobInstanceSpec.scala
@@ -13,6 +13,7 @@ class JobInstanceSpec extends FunSpec with Matchers with BeforeAndAfterAll {
   val conf = new SparkConf()
     .setMaster("local[2]")
     .setAppName("test")
+    .set("spark.driver.allowMultipleContexts", "true")
 
   var sc: SparkContext = _
 

--- a/src/test/scala/io/hydrosphere/mist/master/ExecutionInfoSpec.scala
+++ b/src/test/scala/io/hydrosphere/mist/master/ExecutionInfoSpec.scala
@@ -1,0 +1,32 @@
+package io.hydrosphere.mist.master
+
+import io.hydrosphere.mist.Messages.JobMessages.{JobParams, RunJobRequest}
+import io.hydrosphere.mist.jobs.{JobDetails, JobResult, Action}
+import io.hydrosphere.mist.master.models.JobStartResponse
+import org.scalatest._
+
+import scala.concurrent.Promise
+
+class ExecutionInfoSpec extends FunSpec with Matchers {
+
+  import TestUtils._
+
+  val req = RunJobRequest("id", JobParams("path", "class", Map.empty, Action.Execute))
+
+  it("should return job start response") {
+    val execInfo = ExecutionInfo(req)
+    execInfo.toJobStartResponse shouldBe JobStartResponse("id")
+  }
+
+  it("should return jobresult") {
+    val promise = Promise[Map[String, Any]]
+    promise.success(Map("1" -> "2"))
+
+    val execInfo = ExecutionInfo(req, promise, JobDetails.Status.Finished)
+
+    execInfo.toJobResult.await shouldBe JobResult.success(
+      Map("1" -> "2")
+    )
+
+  }
+}

--- a/src/test/scala/io/hydrosphere/mist/master/JobServiceSpec.scala
+++ b/src/test/scala/io/hydrosphere/mist/master/JobServiceSpec.scala
@@ -7,7 +7,7 @@ import io.hydrosphere.mist.Messages.StatusMessages
 import io.hydrosphere.mist.Messages.StatusMessages.Register
 import io.hydrosphere.mist.Messages.WorkerMessages.{CancelJobCommand, RunJobCommand}
 import io.hydrosphere.mist.jobs.{Action, JobDetails}
-import io.hydrosphere.mist.master.models.{RunMode, EndpointConfig, RunSettings}
+import io.hydrosphere.mist.master.models.{JobStartRequest, RunMode, EndpointConfig, RunSettings}
 import org.scalatest._
 
 import scala.concurrent.duration.Duration
@@ -26,14 +26,15 @@ class JobServiceSpec extends TestKit(ActorSystem("testMasterService"))
       val service = new JobService(workerManager.ref, statusService.ref)
 
       val future = service.startJob(
-        id = "id",
-        endpoint = EndpointConfig("name", "path", "className", "context"),
-        context = TestUtils.contextSettings.default,
-        parameters = Map("1" -> 2),
-        runMode = RunMode.Shared,
-        source = JobDetails.Source.Http,
-        externalId = None
-      )
+        JobStartRequest(
+          id = "id",
+          endpoint = EndpointConfig("name", "path", "className", "context"),
+          context = TestUtils.contextSettings.default,
+          parameters = Map("1" -> 2),
+          runMode = RunMode.Shared,
+          source = JobDetails.Source.Http,
+          externalId = None
+      ))
 
       statusService.expectMsgType[Register]
       statusService.reply(())

--- a/src/test/scala/io/hydrosphere/mist/master/MasterServiceSpec.scala
+++ b/src/test/scala/io/hydrosphere/mist/master/MasterServiceSpec.scala
@@ -38,16 +38,7 @@ class MasterServiceSpec extends TestKit(ActorSystem("testMasterService"))
     when(contexts.getOrDefault(any[String]))
       .thenReturn(Future.successful(TestUtils.contextSettings.default))
 
-    when(jobService.startJob(
-      any[String],
-      any[EndpointConfig],
-      any[ContextConfig],
-      any[Map[String, Any]],
-      any[RunMode],
-      any[JobDetails.Source],
-      any[Option[String]],
-      any[Action]
-    )).thenReturn(Future.successful(
+    when(jobService.startJob(any[JobStartRequest])).thenReturn(Future.successful(
       ExecutionInfo(
         req = RunJobRequest("id", JobParams("path.py", "MyJob", Map("x" -> 1), Action.Execute)),
         status = JobDetails.Status.Queued
@@ -56,7 +47,7 @@ class MasterServiceSpec extends TestKit(ActorSystem("testMasterService"))
 
     val service = new MasterService(jobService, endpoints, contexts, logs)
 
-    val req = JobStartRequest("name", Map("x" -> 1), Some("externalId"))
+    val req = EndpointStartRequest("name", Map("x" -> 1), Some("externalId"))
     val runInfo = service.runJob(req, Source.Http).await
     runInfo.isDefined shouldBe true
   }
@@ -80,7 +71,7 @@ class MasterServiceSpec extends TestKit(ActorSystem("testMasterService"))
 
     val service = new MasterService(jobService, endpoints, contexts, logs)
 
-    val req = JobStartRequest("scalajob", Map("notNumbers" -> Seq(1, 2, 3)), Some("externalId"))
+    val req = EndpointStartRequest("scalajob", Map("notNumbers" -> Seq(1, 2, 3)), Some("externalId"))
     val f = service.runJob(req, Source.Http)
 
     ScalaFutures.whenReady(f.failed) { ex =>

--- a/src/test/scala/io/hydrosphere/mist/master/interfaces/async/AsyncInterfaceSpec.scala
+++ b/src/test/scala/io/hydrosphere/mist/master/interfaces/async/AsyncInterfaceSpec.scala
@@ -3,7 +3,7 @@ package io.hydrosphere.mist.master.interfaces.async
 import io.hydrosphere.mist.jobs.Action
 import io.hydrosphere.mist.jobs.JobDetails.Source
 import io.hydrosphere.mist.master.MasterService
-import io.hydrosphere.mist.master.models.JobStartRequest
+import io.hydrosphere.mist.master.models.EndpointStartRequest
 import org.scalatest.FunSpec
 import org.mockito.Mockito._
 import org.mockito.Matchers._
@@ -28,7 +28,7 @@ class AsyncInterfaceSpec extends FunSpec {
        """.stripMargin
 
     input.putMessage(message)
-    verify(master).runJob(any[JobStartRequest], any[Source])
+    verify(master).runJob(any[EndpointStartRequest], any[Source])
   }
 
 

--- a/src/test/scala/io/hydrosphere/mist/master/interfaces/async/AsyncInterfaceSpec.scala
+++ b/src/test/scala/io/hydrosphere/mist/master/interfaces/async/AsyncInterfaceSpec.scala
@@ -3,14 +3,14 @@ package io.hydrosphere.mist.master.interfaces.async
 import io.hydrosphere.mist.jobs.Action
 import io.hydrosphere.mist.jobs.JobDetails.Source
 import io.hydrosphere.mist.master.MasterService
-import io.hydrosphere.mist.master.models.EndpointStartRequest
+import io.hydrosphere.mist.master.models.{RunMode, DevJobStartRequest, EndpointStartRequest}
 import org.scalatest.FunSpec
 import org.mockito.Mockito._
 import org.mockito.Matchers._
 
 class AsyncInterfaceSpec extends FunSpec {
 
-  it("should run job") {
+  it("should run job on endpoint") {
     val master = mock(classOf[MasterService])
 
     val input = new TestAsyncInput
@@ -29,6 +29,45 @@ class AsyncInterfaceSpec extends FunSpec {
 
     input.putMessage(message)
     verify(master).runJob(any[EndpointStartRequest], any[Source])
+  }
+
+  it("should run dev job") {
+    val master = mock(classOf[MasterService])
+
+    val input = new TestAsyncInput
+
+    val interface = new AsyncInterface(master, input, Source.Async("Test"))
+
+    interface.start()
+
+    val message =
+      s"""
+         |{
+         |  "fakeName": "my-job",
+         |  "path": "path",
+         |  "className": "MyJob",
+         |  "parameters": { "x": "y" },
+         |  "runMode": {
+         |    "type": "exclusive",
+         |    "id": "yoyoyo"
+         |  },
+         |  "context": "foo",
+         |  "externalId": "xxx"
+         |}
+       """.stripMargin
+
+    input.putMessage(message)
+
+    val expected = DevJobStartRequest(
+      fakeName = "my-job",
+      path = "path",
+      className = "MyJob",
+      parameters = Map("x" -> "y"),
+      runMode = RunMode.ExclusiveContext(Some("yoyoyo")),
+      context = "foo",
+      externalId = Some("xxx")
+    )
+    verify(master).devRun(expected, Source.Async("Test"))
   }
 
 

--- a/src/test/scala/io/hydrosphere/mist/master/interfaces/http/DevApiSpec.scala
+++ b/src/test/scala/io/hydrosphere/mist/master/interfaces/http/DevApiSpec.scala
@@ -1,0 +1,41 @@
+package io.hydrosphere.mist.master.interfaces.http
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import io.hydrosphere.mist.Messages.JobMessages.{JobParams, RunJobRequest}
+import io.hydrosphere.mist.MockitoSugar
+import io.hydrosphere.mist.jobs.Action
+import io.hydrosphere.mist.jobs.JobDetails.{Status, Source}
+import io.hydrosphere.mist.master.{ExecutionInfo, MasterService}
+import io.hydrosphere.mist.master.interfaces.JsonCodecs
+import io.hydrosphere.mist.master.models.{DevJobStartRequest, DevJobStartRequestModel}
+import org.scalatest.{Matchers, FunSpec}
+
+import scala.concurrent.Promise
+
+class DevApiSpec extends FunSpec with Matchers with ScalatestRouteTest with MockitoSugar {
+
+  import JsonCodecs._
+  import io.hydrosphere.mist.master.TestUtils._
+
+  it("should start job in dev mode") {
+    val master = mock[MasterService]
+    val api = DevApi.devRoutes(master)
+
+    val req = DevJobStartRequestModel("simple-context", "path", "className", None, None, None, "foo")
+
+    val promise = Promise[Map[String, Any]]
+    promise.success(Map.empty)
+
+    when(master.devRun(any[DevJobStartRequest], any[Source], any[Action]))
+      .thenSuccess(ExecutionInfo(
+        RunJobRequest("id", JobParams("path", "className", Map.empty, Action.Execute)),
+        promise,
+        Status.Finished
+      ))
+
+    Post("/v2/hidden/devrun", req) ~> api ~> check {
+      status shouldBe StatusCodes.OK
+    }
+  }
+}

--- a/src/test/scala/io/hydrosphere/mist/master/interfaces/http/HttpApiSpec.scala
+++ b/src/test/scala/io/hydrosphere/mist/master/interfaces/http/HttpApiSpec.scala
@@ -8,7 +8,7 @@ import io.hydrosphere.mist.jobs.JobDetails.Source
 import io.hydrosphere.mist.jobs._
 import io.hydrosphere.mist.jobs.jar._
 import io.hydrosphere.mist.master.interfaces.JsonCodecs
-import io.hydrosphere.mist.master.models.{FullEndpointInfo, EndpointConfig, JobStartRequest, RunSettings}
+import io.hydrosphere.mist.master.models.{FullEndpointInfo, EndpointConfig, EndpointStartRequest, RunSettings}
 import io.hydrosphere.mist.master.{JobService, MasterService, WorkerLink}
 import org.scalatest.{FunSpec, Matchers}
 
@@ -123,11 +123,9 @@ class HttpApiSpec extends FunSpec with Matchers with MockitoSugar with Scalatest
   it("should start job") {
     val master = mock[MasterService]
     val api = new HttpApi(master).route
-    when(master.forceJobRun(any[JobStartRequest], any[Source], any[Action]))
+    when(master.forceJobRun(any[EndpointStartRequest], any[Source], any[Action]))
       .thenReturn(Future.successful(Some(
-        JobResult.success(
-          Map("yoyo" -> "hello"),
-          JobStartRequest("my-job", Map.empty, None, RunSettings.Default))
+        JobResult.success(Map("yoyo" -> "hello"))
       )))
 
     Post("/api/my-job", Map("Hello" -> "123")) ~> api ~> check {

--- a/src/test/scala/io/hydrosphere/mist/master/interfaces/http/HttpApiV2Spec.scala
+++ b/src/test/scala/io/hydrosphere/mist/master/interfaces/http/HttpApiV2Spec.scala
@@ -11,7 +11,7 @@ import io.hydrosphere.mist.jobs.{Action, JobDetails, JvmJobInfo, PyJobInfo}
 import io.hydrosphere.mist.master.data.EndpointsStorage
 import io.hydrosphere.mist.master.interfaces.JsonCodecs
 import io.hydrosphere.mist.master.logging.LogStorageMappings
-import io.hydrosphere.mist.master.models.{EndpointConfig, FullEndpointInfo, JobStartRequest, JobStartResponse}
+import io.hydrosphere.mist.master.models.{EndpointConfig, FullEndpointInfo, EndpointStartRequest, JobStartResponse}
 import io.hydrosphere.mist.master.{JobService, MasterService, WorkerLink}
 import org.mockito.Matchers._
 import org.mockito.Mockito._
@@ -64,7 +64,7 @@ class HttpApiV2Spec extends FunSpec with Matchers with ScalatestRouteTest {
 
     it("should run job") {
       val master = mock(classOf[MasterService])
-      when(master.runJob(any(classOf[JobStartRequest]), any(classOf[Source])))
+      when(master.runJob(any(classOf[EndpointStartRequest]), any(classOf[Source])))
         .thenReturn(Future.successful(Some(JobStartResponse("1"))))
 
       val route = HttpV2Routes.endpointsRoutes(master)
@@ -77,7 +77,7 @@ class HttpApiV2Spec extends FunSpec with Matchers with ScalatestRouteTest {
     it("should return bad request on futures failed illegal argument exception") {
       val master = mock(classOf[MasterService])
 
-      when(master.runJob(any(classOf[JobStartRequest]), any(classOf[Source])))
+      when(master.runJob(any(classOf[EndpointStartRequest]), any(classOf[Source])))
         .thenReturn(Future.failed(new IllegalArgumentException("argument missing")))
 
       val route = HttpV2Routes.endpointsRoutes(master)
@@ -90,7 +90,7 @@ class HttpApiV2Spec extends FunSpec with Matchers with ScalatestRouteTest {
     it("should return 500 on future`s any exception except iae") {
       val master = mock(classOf[MasterService])
 
-      when(master.runJob(any(classOf[JobStartRequest]), any(classOf[Source])))
+      when(master.runJob(any(classOf[EndpointStartRequest]), any(classOf[Source])))
         .thenReturn(Future.failed(new IllegalStateException("some exception")))
 
       val route = HttpV2Routes.endpointsRoutes(master)


### PR DESCRIPTION
Old way for running jobs without endpoints.
Expected json data for request:
```js
{
   "fakeName": "my-job",
    "path": "path",
    "className": "MyJob",
    "parameters": { "x": "y" },
    // default mode
    "runMode": {
        "type": "shared"
     }
    // exclusive worker
    "runMode": {
        "type": "exclusive",
         "id": "yoyoyo"
      },
     "context": "foo",
     "externalId": "xxx"
 }
```

