### PR TITLE
Remoting - max frame size

### DIFF
--- a/src/main/resources/master.conf
+++ b/src/main/resources/master.conf
@@ -106,6 +106,7 @@ akka {
     netty.tcp {
       hostname = ${mist.cluster.host}
       port = ${mist.cluster.port}
+      maximum-frame-size = 5242880b
     }
     transport-failure-detector {
       heartbeat-interval = 30s

--- a/src/main/resources/worker.conf
+++ b/src/main/resources/worker.conf
@@ -20,6 +20,7 @@ akka {
     netty.tcp {
       hostname = "127.0.0.1"
       port = 0
+      maximum-frame-size = 5242880b
     }
     transport-failure-detector {
       heartbeat-interval = 30s


### PR DESCRIPTION
Increase max remote frame size to 5mb for large job results