### PR TITLE
Fix/worker logging

### DIFF
--- a/bin/mist-worker
+++ b/bin/mist-worker
@@ -6,8 +6,7 @@ JAVA=$(which java)
 ASSEMBLY_JAR=$MIST_HOME/mist.jar
 
 CONFIG_FILE=$MIST_HOME/configs/default.conf
-NAME=""
-CONTEXT=""
+WORKER_NAME=""
 JAVA_ARGS=""
 RUNNER="local"
 MODE="shared"
@@ -37,6 +36,11 @@ do
       RUNNER="$2"
       shift
       ;;
+
+    --name)
+      WORKER_NAME="$2"
+      shift
+      ;;
   esac
 shift
 done
@@ -52,6 +56,11 @@ function startWorker() {
 
     SPARK_SUBMIT="${SPARK_HOME}/bin/spark-submit"
     MAIN_CLASS="io.hydrosphere.mist.worker.Worker"
+
+    LOGGER_CONF=$MIST_HOME/configs/logging/log4j.worker.properties
+    DRIVER_JAVA_OPTIONS="$DRIVER_JAVA_OPTIONS -Dmist.home=$MIST_HOME"
+    DRIVER_JAVA_OPTIONS="$DRIVER_JAVA_OPTIONS -Dmist.worker.name=$WORKER_NAME"
+    DRIVER_JAVA_OPTIONS="$DRIVER_JAVA_OPTIONS -Dlog4j.configuration=file:$LOGGER_CONF"
     DRIVER_JAVA_OPTIONS="$DRIVER_JAVA_OPTIONS $JAVA_ARGS"
 
     exec $SPARK_SUBMIT --class $MAIN_CLASS --driver-java-options "$DRIVER_JAVA_OPTIONS" $RUN_OPTIONS $ASSEMBLY_JAR $ORIGIN_ARGS

--- a/configs/logging/log4j.worker.properties
+++ b/configs/logging/log4j.worker.properties
@@ -1,0 +1,21 @@
+log4j.rootCategory=INFO, file
+
+log4j.appender.file=org.apache.log4j.FileAppender
+log4j.appender.file.File=${mist.home}/logs/worker-${mist.worker.name}.log
+log4j.appender.file.append=true
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+
+log4j.logger.org.apache.spark=WARN
+
+# Settings to quiet third party logs that are too verbose
+log4j.logger.org.spark-project.jetty=WARN
+log4j.logger.org.spark-project.jetty.util.component.AbstractLifeCycle=ERROR
+log4j.logger.org.apache.spark.repl.SparkIMain$exprTyper=INFO
+log4j.logger.org.apache.spark.repl.SparkILoop$SparkILoopInterpreter=INFO
+log4j.logger.org.apache.parquet=ERROR
+log4j.logger.parquet=ERROR
+
+# SPARK-9183: Settings to avoid annoying messages when looking up nonexistent UDFs in SparkSQL with Hive support
+log4j.logger.org.apache.hadoop.hive.metastore.RetryingHMSHandler=FATAL
+log4j.logger.org.apache.hadoop.hive.ql.exec.FunctionRegistry=ERROR

--- a/src/main/scala/io/hydrosphere/mist/master/WorkersManager.scala
+++ b/src/main/scala/io/hydrosphere/mist/master/WorkersManager.scala
@@ -113,6 +113,7 @@ class WorkersManager(
       sender() ! akka.actor.Status.Success(())
 
     case r @ WorkerRegistration(name, address) =>
+      log.info("Received worker registration - name: {}, address: {} ", name, address)
       val selection = cluster.system.actorSelection(RootActorPath(address) / "user" / s"worker-$name")
       selection.resolveOne(5.second).onComplete({
         case Success(ref) => self ! WorkerResolved(name, address, ref)
@@ -121,6 +122,7 @@ class WorkersManager(
       })
 
     case r @ WorkerResolved(name, address, ref) =>
+      log.info("Worker resolved - name: {}, address: {} ", name, address)
       workerStates.get(name) match {
         case Some(state) =>
           val next = Started(state.frontend, address, ref)

--- a/src/main/scala/io/hydrosphere/mist/worker/ClusterWorker.scala
+++ b/src/main/scala/io/hydrosphere/mist/worker/ClusterWorker.scala
@@ -40,7 +40,9 @@ class ClusterWorker(
 
   def joined(master: Address): Receive = {
     case info: WorkerInitInfo =>
+      log.info("Received init info {}", info)
       val worker = startWorker(info)
+      log.info("Worker actor started")
       register(master)
       context become initialized(master, worker)
   }


### PR DESCRIPTION
Setup logging for mist workers (previously they used configuration from spark).
By default logs from each worker will be stored at ${MIST_HOME}/logs/worker-$name.log