### PR TITLE
Fix #276: increase http.server.timeout to 10 minutes

### DIFF
--- a/src/main/resources/master.conf
+++ b/src/main/resources/master.conf
@@ -121,4 +121,5 @@ akka {
     roles = ["master"]
   }
 
+  http.server.idle-timeout = 10 minutes
 }


### PR DESCRIPTION
There is no other way to accept long-live websocket connections for old akka-http