### PR TITLE
Feature/ws keep alive msg

### DIFF
--- a/mist/master/src/main/resources/master.conf
+++ b/mist/master/src/main/resources/master.conf
@@ -13,6 +13,7 @@ mist {
     port = 2004
     ui = ${mist.work-directory}"/ui"
     ui = ${?MIST_UI_DIR}
+    ws-keepalive-tick = 1 minute // it must be less than akka.http.server.idle-timeout
   }
 
   mqtt {

--- a/mist/master/src/main/scala/io/hydrosphere/mist/master/MasterServer.scala
+++ b/mist/master/src/main/scala/io/hydrosphere/mist/master/MasterServer.scala
@@ -176,7 +176,7 @@ object MasterServer extends Logger {
     val http = {
       val apiv2 = {
         val api = HttpV2Routes.apiWithCORS(mainService, artifacts)
-        val ws = new WSApi(streamer)
+        val ws = new WSApi(streamer)(config.keepAliveTick)
         // order is important!
         // api router can't chain unhandled calls, because it's wrapped in cors directive
         ws.route ~ api

--- a/mist/master/src/main/scala/io/hydrosphere/mist/master/Messages.scala
+++ b/mist/master/src/main/scala/io/hydrosphere/mist/master/Messages.scala
@@ -34,6 +34,7 @@ object Messages {
     case class FailedEvent(id: String, time: Long, error: String) extends UpdateStatusEvent
 
     case class ReceivedLogs(id: String, events: Seq[LogEvent], fileOffset: Long) extends SystemEvent
+    case object KeepAliveEvent extends SystemEvent
 
     // return full job details
     case object RunningJobs

--- a/mist/master/src/main/scala/io/hydrosphere/mist/master/configs.scala
+++ b/mist/master/src/main/scala/io/hydrosphere/mist/master/configs.scala
@@ -34,13 +34,19 @@ object HostPortConfig {
 case class HttpConfig(
   host: String,
   port: Int,
-  uiPath: String
+  uiPath: String,
+  keepAliveTick: FiniteDuration
 )
 
 object HttpConfig {
 
   def apply(config: Config): HttpConfig =
-    HttpConfig(config.getString("host"), config.getInt("port"), config.getString("ui"))
+    HttpConfig(
+      config.getString("host"),
+      config.getInt("port"),
+      config.getString("ui"),
+      config.getFiniteDuration("ws-keepalive-tick")
+    )
 }
 
 

--- a/mist/master/src/main/scala/io/hydrosphere/mist/master/interfaces/jsonCodecs.scala
+++ b/mist/master/src/main/scala/io/hydrosphere/mist/master/interfaces/jsonCodecs.scala
@@ -255,6 +255,7 @@ trait JsonCodecs extends SprayJsonSupport
         case x: FailedEvent => "failed" -> x.toJson
         case x: ReceivedLogs => "logs" -> x.toJson
         case x: JobFileDownloadingEvent => "job-file-downloading" -> x.toJson
+        case KeepAliveEvent => "keep-alive" -> JsObject(Map.empty[String, JsValue])
       }
 
       val merged = initial.asJsObject.fields + ("event" -> JsString(name))

--- a/mist/master/src/test/scala/io/hydrosphere/mist/master/InfoProviderSpec.scala
+++ b/mist/master/src/test/scala/io/hydrosphere/mist/master/InfoProviderSpec.scala
@@ -4,8 +4,8 @@ import io.hydrosphere.mist.core.MockitoSugar
 import io.hydrosphere.mist.master.data.ContextsStorage
 import org.scalatest.{FunSpec, Matchers}
 
+import scala.concurrent.duration._
 import scala.concurrent.Future
-
 class InfoProviderSpec extends FunSpec with Matchers with MockitoSugar {
 
   import TestUtils._
@@ -17,7 +17,7 @@ class InfoProviderSpec extends FunSpec with Matchers with MockitoSugar {
 
     val provider = new InfoProvider(
       LogServiceConfig("logHost", 999, ""),
-      HttpConfig("localhost", 2004, "ui"),
+      HttpConfig("localhost", 2004, "ui", 30 seconds),
       contexts,
       "/tmp"
     )

--- a/mist/master/src/test/scala/io/hydrosphere/mist/master/WorkerRunnersSpec.scala
+++ b/mist/master/src/test/scala/io/hydrosphere/mist/master/WorkerRunnersSpec.scala
@@ -13,7 +13,7 @@ class WorkerRunnersSpec extends FunSpec with Matchers{
     it("should build arguments for worker") {
       val cfg = MasterConfig(
         cluster = HostPortConfig("0.0.0.0", 2345),
-        http = HttpConfig("0.0.0.0", 2004, "path"),
+        http = HttpConfig("0.0.0.0", 2004, "path", 30 seconds),
         mqtt = None,
         kafka = None,
         logs = LogServiceConfig("logsHost", 5000, ""),

--- a/mist/master/src/test/scala/io/hydrosphere/mist/master/interfaces/http/WsApiSpec.scala
+++ b/mist/master/src/test/scala/io/hydrosphere/mist/master/interfaces/http/WsApiSpec.scala
@@ -9,12 +9,14 @@ import io.hydrosphere.mist.master.Messages.StatusMessages._
 import io.hydrosphere.mist.master.EventsStreamer
 import org.mockito.Mockito._
 import org.scalatest.{FunSpec, Matchers}
+import scala.concurrent.duration._
 
 class WsApiSpec extends FunSpec
   with Matchers
   with ScalatestRouteTest {
 
   val mat = ActorMaterializer()
+  implicit val keepAlive = 30 seconds
 
   it("should stream all events") {
     val testSource = Source[UpdateStatusEvent](List(


### PR DESCRIPTION
Fix issue when the server closes ws connection after `akka.http.server.idle-timeout`. Now server will send every `mist.http.ws-keepalive-tick` time the `KeepAliveEvent` message  with following structure:
```json
{
    "event": "keep-alive"
}
```