### PR TITLE
Fix log store flow

### DIFF
--- a/mist/master/src/main/scala/io/hydrosphere/mist/master/EventsStreamer.scala
+++ b/mist/master/src/main/scala/io/hydrosphere/mist/master/EventsStreamer.scala
@@ -3,7 +3,8 @@ package io.hydrosphere.mist.master
 import akka.actor._
 import akka.stream.OverflowStrategy
 import akka.stream.scaladsl._
-import io.hydrosphere.mist.master.Messages.StatusMessages.{UpdateStatusEvent, SystemEvent}
+import io.hydrosphere.mist.master.Messages.StatusMessages.{SystemEvent, UpdateStatusEvent}
+import io.hydrosphere.mist.master.logging.LogStreams
 
 trait EventsStreamer {
 
@@ -18,14 +19,13 @@ trait EventsStreamer {
   */
 object EventsStreamer {
 
-  private val BufferSize = 10000
 
   def apply(system: ActorSystem): EventsStreamer = {
     val actor = system.actorOf(Props(new BroadcastSource))
 
     new EventsStreamer {
       override def eventsSource(): Source[SystemEvent, akka.NotUsed] = {
-        Source.actorRef[UpdateStatusEvent](BufferSize, OverflowStrategy.dropHead)
+        Source.actorRef[SystemEvent](LogStreams.LogEventBufferSize, OverflowStrategy.dropHead)
           .mapMaterializedValue(ref => {actor.tell("subscribe", ref); akka.NotUsed})
       }
 

--- a/mist/master/src/main/scala/io/hydrosphere/mist/master/EventsStreamer.scala
+++ b/mist/master/src/main/scala/io/hydrosphere/mist/master/EventsStreamer.scala
@@ -18,14 +18,14 @@ trait EventsStreamer {
   */
 object EventsStreamer {
 
-  private val BufferSize = 500
+  private val BufferSize = 10000
 
   def apply(system: ActorSystem): EventsStreamer = {
     val actor = system.actorOf(Props(new BroadcastSource))
 
     new EventsStreamer {
       override def eventsSource(): Source[SystemEvent, akka.NotUsed] = {
-        Source.actorRef[UpdateStatusEvent](BufferSize, OverflowStrategy.dropTail)
+        Source.actorRef[UpdateStatusEvent](BufferSize, OverflowStrategy.dropHead)
           .mapMaterializedValue(ref => {actor.tell("subscribe", ref); akka.NotUsed})
       }
 

--- a/mist/master/src/main/scala/io/hydrosphere/mist/master/logging/LogStreams.scala
+++ b/mist/master/src/main/scala/io/hydrosphere/mist/master/logging/LogStreams.scala
@@ -88,7 +88,7 @@ trait LogStreams extends Logger {
     writer: LogsWriter,
     streamer: EventsStreamer
   )(implicit mat: ActorMaterializer): ActorRef = {
-    val source = Source.actorRef[LogEvent](10000, OverflowStrategy.dropHead)
+    val source = Source.actorRef[LogEvent](LogStreams.LogEventBufferSize, OverflowStrategy.dropHead)
 
     val sink = eventStreamerSink(streamer)
 
@@ -135,6 +135,8 @@ class LogService(
 }
 
 object LogStreams extends LogStreams {
+
+  val LogEventBufferSize = 10000
 
   def runService(
     host: String,

--- a/mist/master/src/main/scala/io/hydrosphere/mist/master/logging/LogStreams.scala
+++ b/mist/master/src/main/scala/io/hydrosphere/mist/master/logging/LogStreams.scala
@@ -2,40 +2,52 @@ package io.hydrosphere.mist.master.logging
 
 import java.nio.ByteOrder
 
-import akka.NotUsed
 import akka.actor.{ActorRef, ActorSystem}
-import akka.pattern.Backoff
 import akka.stream.scaladsl._
-import akka.stream.{ActorAttributes, ActorMaterializer, Attributes, OverflowStrategy}
+import akka.stream.{ActorAttributes, ActorMaterializer, OverflowStrategy}
 import akka.util.ByteString
+import akka.{Done, NotUsed}
 import com.twitter.chill.{KryoPool, ScalaKryoInstantiator}
 import io.hydrosphere.mist.api.logging.MistLogging.LogEvent
 import io.hydrosphere.mist.master.Messages.StatusMessages.ReceivedLogs
 import io.hydrosphere.mist.master.{EventsStreamer, LogStoragePaths}
+import io.hydrosphere.mist.utils.Logger
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-import scala.concurrent.duration._
+import scala.util.{Failure, Success, Try}
 
-trait LogStreams {
+trait LogStreams extends Logger {
 
   import ActorAttributes.supervisionStrategy
   import akka.stream.Supervision.resumingDecider
-
 
   /**
     * Storing batched logEvent via writer and produce Event
     *   for async interfaces
     */
   def storeFlow(writer: LogsWriter): Flow[LogEvent, LogUpdate, NotUsed] = {
-    Flow[LogEvent]
-      .groupBy(1000, _.from)
-      .groupedWithin(1000, 1 second)
-      .mapAsync(4)(events => {
-        val jobId = events.head.from
-        writer.write(jobId, events)
+    def fTry[A](f: Future[A]): Future[Try[A]] = {
+      f.map(a => Success(a)).recover({case e => Failure(e)})
+    }
+
+    def batchWrite(elems: Seq[LogEvent]): Future[List[LogUpdate]] = {
+      val futures = elems.groupBy(_.from).map({case (id, perJob) => fTry(writer.write(id, perJob))})
+      Future.sequence(futures).map(all => {
+        all.foldLeft(List.empty[LogUpdate]) {
+          case (acc, Success(upd)) => upd :: acc
+          case (acc, Failure(e)) =>
+            logger.error("Batch writing error", e)
+            acc
+        }
       })
+    }
+
+    Flow[LogEvent]
+      .batch(1000, e => Vector(e))((events, e) => events :+ e)
+      .mapAsync(1)(batchWrite)
       .withAttributes(supervisionStrategy(resumingDecider))
-      .mergeSubstreams
+      .mapConcat(identity)
   }
 
   /**
@@ -62,7 +74,7 @@ trait LogStreams {
       .filter(_ => false)
   }
 
-  def eventStreamerSink(streamer: EventsStreamer): Sink[LogUpdate, Any] = {
+  def eventStreamerSink(streamer: EventsStreamer): Sink[LogUpdate, Future[Done]] = {
     Sink.foreach[LogUpdate](upd => {
       val event = ReceivedLogs(upd.jobId, upd.events, upd.bytesOffset)
       streamer.push(event)
@@ -77,9 +89,18 @@ trait LogStreams {
     streamer: EventsStreamer
   )(implicit mat: ActorMaterializer): ActorRef = {
     val source = Source.actorRef[LogEvent](10000, OverflowStrategy.dropHead)
+
     val sink = eventStreamerSink(streamer)
 
-    source.via(storeFlow(writer)).toMat(sink)(Keep.left).run()
+    val (ref, f) = source.via(storeFlow(writer))
+      .toMat(sink)(Keep.both).run()
+
+    f.onComplete({
+      case Success(_) => logger.info("Log storing flow was completed")
+      case Failure(e) => logger.error("Log storing flow was completed with failure", e)
+    })
+
+    ref
   }
 
   /**

--- a/mist/master/src/test/resources/log4j.properties
+++ b/mist/master/src/test/resources/log4j.properties
@@ -22,16 +22,8 @@ log4j.appender.console.target=System.err
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
 log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
 
-log4j.logger.org.apache.spark=WARN
+log4j.appender.console.filter.ex=org.apache.log4j.filter.ExpressionFilter
+log4j.appender.console.filter.ex.expression=EXCEPTION ~= io.hydrosphere.mist.master.FilteredException
+log4j.appender.console.filter.ex.acceptOnMatch=false
 
-# Settings to quiet third party logs that are too verbose
-log4j.logger.org.spark-project.jetty=WARN
-log4j.logger.org.spark-project.jetty.util.component.AbstractLifeCycle=ERROR
-log4j.logger.org.apache.spark.repl.SparkIMain$exprTyper=INFO
-log4j.logger.org.apache.spark.repl.SparkILoop$SparkILoopInterpreter=INFO
-log4j.logger.org.apache.parquet=ERROR
-log4j.logger.parquet=ERROR
 
-# SPARK-9183: Settings to avoid annoying messages when looking up nonexistent UDFs in SparkSQL with Hive support
-log4j.logger.org.apache.hadoop.hive.metastore.RetryingHMSHandler=FATAL
-log4j.logger.org.apache.hadoop.hive.ql.exec.FunctionRegistry=ERROR

--- a/mist/master/src/test/scala/io/hydrosphere/mist/master/FilteredException.scala
+++ b/mist/master/src/test/scala/io/hydrosphere/mist/master/FilteredException.scala
@@ -1,0 +1,6 @@
+package io.hydrosphere.mist.master
+
+class FilteredException extends RuntimeException
+object FilteredException {
+  def apply(): FilteredException = new FilteredException()
+}

--- a/mist/master/src/test/scala/io/hydrosphere/mist/master/logging/LogStreamsSpec.scala
+++ b/mist/master/src/test/scala/io/hydrosphere/mist/master/logging/LogStreamsSpec.scala
@@ -6,6 +6,7 @@ import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.testkit.TestKit
 import io.hydrosphere.mist.api.logging.MistLogging.LogEvent
 import io.hydrosphere.mist.core.MockitoSugar
+import io.hydrosphere.mist.master.FilteredException
 import org.mockito.Mockito.verify
 import org.scalatest.{FunSpecLike, Matchers}
 
@@ -40,9 +41,9 @@ class LogStreamsSpec extends TestKit(ActorSystem("log-service-test"))
     val writer = mock[LogsWriter]
     when(writer.write(any[String], any[Seq[LogEvent]]))
       .thenSuccess(LogUpdate("id", Seq(event), 1))
-      .thenFailure(new RuntimeException("error"))
+      .thenFailure(FilteredException())
       .thenSuccess(LogUpdate("id", Seq(event), 1))
-      .thenFailure(new RuntimeException("error"))
+      .thenFailure(FilteredException())
       .thenSuccess(LogUpdate("id", Seq(event), 1))
 
     val in = (1 to 5).map(i => LogEvent.mkDebug(s"job-$i", "message"))


### PR DESCRIPTION
Flow.groupBy doesn't work with unlimited count of unique keys