### PR TITLE
Fix broken Kafka client

### DIFF
--- a/mist/master/src/main/scala/io/hydrosphere/mist/master/interfaces/async/kafka/KafkaClient.scala
+++ b/mist/master/src/main/scala/io/hydrosphere/mist/master/interfaces/async/kafka/KafkaClient.scala
@@ -33,7 +33,7 @@ object TopicProducer {
     topic: String): TopicProducer[String, String] = {
 
     val props = new java.util.Properties()
-    props.put("bootstrap.servers", s"$host:port")
+    props.put("bootstrap.servers", s"$host:$port")
 
     val producer = new KafkaProducer(props, new StringSerializer, new StringSerializer)
     new TopicProducer(producer, topic)


### PR DESCRIPTION
The Kafka client breaks because the port variable isn't prefixed with $