### PR TITLE
Feature/pagination resp

### DIFF
--- a/docs/src/main/tut/08_http_api.md
+++ b/docs/src/main/tut/08_http_api.md
@@ -66,7 +66,7 @@ position: 8
           <li>limit - optional (default 25)</li>
           <li>offset - optional (default 0)</li>
           <li>status - optional, repeated (values: started, finished ... )</li>
-          <li>paginate - boolean (default false) - response with struct `{"jobs": [array of jobs], "hasNext": boolean}`</li>
+          <li>paginate - boolean (default false) - response with struct `{"jobs": [array of jobs], "total": int}`</li>
         </ul>
       </td>
       <td>List of jobs that was ran with given function</td>
@@ -94,7 +94,7 @@ position: 8
           <li>limit - optional (default 25)</li>
           <li>offset - optional (default 0)</li>
           <li>status - optional, repeated (values: started, finished ... )</li>
-          <li>paginate - boolean (default false) - response with struct `{"jobs": [array of jobs], "hasNext": boolean}`</li>
+          <li>paginate - boolean (default false) - response with struct `{"jobs": [array of jobs], "total": int}`</li>
         </ul>
       </td>
       <td>List of all jobs that was ran on all functions</td>
@@ -157,7 +157,7 @@ position: 8
           <li>limit - optional (default 25)</li>
           <li>offset - optional (default 0)</li>
           <li>status - optional, repeated (values: started, finished ... )</li>
-          <li>paginate - boolean (default false) - response with struct `{"jobs": [array of jobs], "hasNext": boolean}`</li>
+          <li>paginate - boolean (default false) - response with struct `{"jobs": [array of jobs], "total": int}`</li>
         </ul>
       </td>
       <td>List of all jobs that was ran on worker</td>

--- a/docs/src/main/tut/08_http_api.md
+++ b/docs/src/main/tut/08_http_api.md
@@ -66,9 +66,10 @@ position: 8
           <li>limit - optional (default 25)</li>
           <li>offset - optional (default 0)</li>
           <li>status - optional, repeated (values: started, finished ... )</li>
+          <li>paginate - boolean (default false) - response with struct `{"jobs": [array of jobs], "hasNext": boolean}`</li>
         </ul>
       </td>
-      <td>List of jobs that was run with given function</td>
+      <td>List of jobs that was ran with given function</td>
     </tr>
 
   </tbody>
@@ -93,9 +94,10 @@ position: 8
           <li>limit - optional (default 25)</li>
           <li>offset - optional (default 0)</li>
           <li>status - optional, repeated (values: started, finished ... )</li>
+          <li>paginate - boolean (default false) - response with struct `{"jobs": [array of jobs], "hasNext": boolean}`</li>
         </ul>
       </td>
-      <td>List of all jobs that was runned on all functions</td>
+      <td>List of all jobs that was ran on all functions</td>
     </tr>
     <tr>
       <td>GET</td>
@@ -146,6 +148,19 @@ position: 8
       <td>/v2/api/workers/{id}</td>
       <td>None</td>
       <td>Get detailed worker info(context config, jobs, etc..)</td>
+    </tr>
+    <tr>
+      <td>GET</td>
+      <td>/v2/api/workers/{id}/jobs</td>
+      <td>Query params:
+        <ul>
+          <li>limit - optional (default 25)</li>
+          <li>offset - optional (default 0)</li>
+          <li>status - optional, repeated (values: started, finished ... )</li>
+          <li>paginate - boolean (default false) - response with struct `{"jobs": [array of jobs], "hasNext": boolean}`</li>
+        </ul>
+      </td>
+      <td>List of all jobs that was ran on worker</td>
     </tr>
   </tbody>
 </table>

--- a/mist/master/src/main/scala/io/hydrosphere/mist/master/JobDetailsRequest.scala
+++ b/mist/master/src/main/scala/io/hydrosphere/mist/master/JobDetailsRequest.scala
@@ -1,0 +1,28 @@
+package io.hydrosphere.mist.master
+
+sealed trait FilterClause
+
+object FilterClause {
+  case class ByFunctionId(id: String) extends FilterClause
+  case class ByWorkerId(id: String) extends FilterClause
+  case class ByStatuses(statuses: Seq[JobDetails.Status]) extends FilterClause
+}
+
+case class JobDetailsRequest(
+  limit: Int,
+  offset: Int,
+  filters: Seq[FilterClause]
+) {
+
+  def withFilter(f: FilterClause): JobDetailsRequest = copy(filters = f +: filters)
+}
+
+object JobDetailsRequest {
+  def apply(limit: Int, offset: Int): JobDetailsRequest = JobDetailsRequest(limit, offset, Seq.empty)
+}
+
+case class JobDetailsResponse(
+  jobs: Seq[JobDetails],
+  hasNext: Boolean
+)
+

--- a/mist/master/src/main/scala/io/hydrosphere/mist/master/JobDetailsRequest.scala
+++ b/mist/master/src/main/scala/io/hydrosphere/mist/master/JobDetailsRequest.scala
@@ -23,6 +23,6 @@ object JobDetailsRequest {
 
 case class JobDetailsResponse(
   jobs: Seq[JobDetails],
-  hasNext: Boolean
+  total: Int
 )
 

--- a/mist/master/src/main/scala/io/hydrosphere/mist/master/execution/WorkerLink.scala
+++ b/mist/master/src/main/scala/io/hydrosphere/mist/master/execution/WorkerLink.scala
@@ -1,7 +1,6 @@
 package io.hydrosphere.mist.master.execution
 
 import io.hydrosphere.mist.core.CommonData.WorkerInitInfo
-import io.hydrosphere.mist.master.models.JobDetailsLink
 
 case class WorkerLink(
   name: String,
@@ -10,10 +9,3 @@ case class WorkerLink(
   initInfo: WorkerInitInfo
 )
 
-case class WorkerFullInfo(
-  name: String,
-  address: String,
-  sparkUi: Option[String],
-  jobs: Seq[JobDetailsLink],
-  initInfo: WorkerInitInfo
-)

--- a/mist/master/src/main/scala/io/hydrosphere/mist/master/interfaces/http/HttpV2Routes.scala
+++ b/mist/master/src/main/scala/io/hydrosphere/mist/master/interfaces/http/HttpV2Routes.scala
@@ -99,14 +99,6 @@ object HttpV2Base {
     }
   }
 
-  def withValidatedStatuses(s: Iterable[String])
-      (m: Seq[JobDetails.Status]=> ToResponseMarshallable): StandardRoute = {
-    toStatuses(s) match {
-      case Left(errors) => complete { HttpResponse(StatusCodes.BadRequest, entity = errors.mkString(",")) }
-      case Right(statuses) => complete(m(statuses))
-    }
-  }
-
   val statusesQuery: Directive1[Seq[JobDetails.Status]] = {
     parameter('status *).flatMap(raw => {
       toStatuses(raw) match {

--- a/mist/master/src/main/scala/io/hydrosphere/mist/master/interfaces/jsonCodecs.scala
+++ b/mist/master/src/main/scala/io/hydrosphere/mist/master/interfaces/jsonCodecs.scala
@@ -6,10 +6,10 @@ import java.time.format.{DateTimeFormatter, DateTimeParseException}
 import io.hydrosphere.mist.core.CommonData.{Action, JobParams, WorkerInitInfo}
 import io.hydrosphere.mist.core.logging.LogEvent
 import io.hydrosphere.mist.master.Messages.StatusMessages._
-import io.hydrosphere.mist.master.execution.{WorkerFullInfo, WorkerLink}
+import io.hydrosphere.mist.master.execution.WorkerLink
 import io.hydrosphere.mist.master.interfaces.http._
 import io.hydrosphere.mist.master.models._
-import io.hydrosphere.mist.master.{JobDetails, JobResult}
+import io.hydrosphere.mist.master.{JobDetails, JobDetailsResponse, JobResult}
 import mist.api.{data => mdata}
 import spray.json._
 
@@ -227,12 +227,10 @@ trait JsonCodecs extends SprayJsonSupport
   implicit val devJobStartReqModelF = jsonFormat7(DevJobStartRequestModel.apply)
 
 
-  implicit val jobDetailsLinkF = jsonFormat8(JobDetailsLink)
-  implicit val workerFullInfoF = jsonFormat5(WorkerFullInfo)
-
   implicit val contextConfigF = jsonFormat9(ContextConfig.apply)
 
   implicit val contextCreateRequestF = jsonFormat9(ContextCreateRequest.apply)
+  implicit val jobDetailsResponseF = jsonFormat2(JobDetailsResponse.apply)
 
   implicit val updateEventF = new JsonFormat[SystemEvent] {
 

--- a/mist/master/src/main/scala/io/hydrosphere/mist/master/models/models.scala
+++ b/mist/master/src/main/scala/io/hydrosphere/mist/master/models/models.scala
@@ -95,13 +95,3 @@ case class DevJobStartRequestModel(
     )
   }
 }
-case class JobDetailsLink(
-  jobId: String,
-  source: JobDetails.Source,
-  startTime: Option[Long] = None,
-  endTime: Option[Long] = None,
-  status: JobDetails.Status = JobDetails.Status.Initialized,
-  function: String,
-  workerId: Option[String],
-  createTime: Long = System.currentTimeMillis()
-)

--- a/mist/master/src/main/scala/io/hydrosphere/mist/master/store/JobRepository.scala
+++ b/mist/master/src/main/scala/io/hydrosphere/mist/master/store/JobRepository.scala
@@ -1,6 +1,6 @@
 package io.hydrosphere.mist.master.store
 
-import io.hydrosphere.mist.master.JobDetails
+import io.hydrosphere.mist.master.{JobDetails, JobDetailsRequest, JobDetailsResponse}
 import io.hydrosphere.mist.master.JobDetails.Status
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -13,19 +13,12 @@ trait JobRepository {
 
   def get(jobId: String): Future[Option[JobDetails]]
 
-  def getByFunctionId(id: String, limit: Int, offset: Int, statuses: Seq[JobDetails.Status]): Future[Seq[JobDetails]]
-  def getByFunctionId(id: String, limit: Int, offset: Int): Future[Seq[JobDetails]] =
-    getByFunctionId(id, limit, offset, Seq.empty)
-
   def update(jobDetails: JobDetails): Future[Unit]
 
   def filteredByStatuses(statuses: Seq[JobDetails.Status]): Future[Seq[JobDetails]]
 
   def getAll(limit: Int, offset: Int, statuses: Seq[JobDetails.Status]): Future[Seq[JobDetails]]
   def getAll(limit: Int, offset: Int): Future[Seq[JobDetails]] = getAll(limit, offset, Seq.empty)
-
-  def getByWorkerIdBeforeDate(workerId: String, timestamp: Long): Future[Seq[JobDetails]]
-  def getByWorkerId(workerId: String): Future[Seq[JobDetails]]
 
   def clear(): Future[Unit]
 
@@ -37,5 +30,7 @@ trait JobRepository {
       case None => Future.failed(new IllegalStateException(s"Not found job: $jobId"))
     }
   }
+
+  def getJobs(req: JobDetailsRequest): Future[JobDetailsResponse]
 }
 

--- a/mist/master/src/test/scala/io/hydrosphere/mist/master/interfaces/http/HttpApiV2Spec.scala
+++ b/mist/master/src/test/scala/io/hydrosphere/mist/master/interfaces/http/HttpApiV2Spec.scala
@@ -99,7 +99,7 @@ class HttpApiV2Spec extends FunSpec
         Seq(JobDetails("id", "1",
           JobParams("path", "className", JsMap.empty, Action.Execute),
           "context", None, JobDetails.Source.Http)
-        ), false
+        ), 1
       ))
 
       val route = HttpV2Routes.workerRoutes(execution)
@@ -141,7 +141,7 @@ class HttpApiV2Spec extends FunSpec
         Seq(JobDetails("id", "1",
           JobParams("path", "className", JsMap.empty, Action.Execute),
           "context", None, JobDetails.Source.Http)
-        ), false
+        ), 1
       ))
 
       val route = HttpV2Routes.functionRoutes(master)
@@ -263,7 +263,7 @@ class HttpApiV2Spec extends FunSpec
       val master = mock[MainService]
       when(master.execution).thenReturn(execution)
       when(execution.getHistory(any[JobDetailsRequest]))
-        .thenSuccess(JobDetailsResponse(Seq(jobDetails), false))
+        .thenSuccess(JobDetailsResponse(Seq(jobDetails), 1))
 
       val route = HttpV2Routes.jobsRoutes(master)
 


### PR DESCRIPTION
- Add `v2/api/worker/{id}/jobs` route
- Add `paginate=boolean` parameter for `jobs` routes.  It affects response json format:
   - `false` (default) - `[array of jobs]`
   - `true` - `{"jobs": [array of jobs], "total": int}`