### PR TITLE
Fix -  remote logs stream closes during `finalize` of AppenderSkeleton

### DIFF
--- a/mist/worker/src/main/scala/io/hydrosphere/mist/worker/logging/RemoteAppender.scala
+++ b/mist/worker/src/main/scala/io/hydrosphere/mist/worker/logging/RemoteAppender.scala
@@ -25,7 +25,7 @@ class RemoteAppender(sourceId: String, logsWriter: LogsWriter) extends AppenderS
     logsWriter.write(evt)
   }
 
-  override def close(): Unit = logsWriter.close()
+  override def close(): Unit = ()
 
   override def requiresLayout(): Boolean = true
 }


### PR DESCRIPTION
Remote appender could be closed unexpectedly:
```
at io.hydrosphere.mist.worker.logging.RemoteAppender.close(RemoteAppender.scala:30)
	at org.apache.log4j.AppenderSkeleton.finalize(AppenderSkeleton.java:144)
	at java.lang.System$2.invokeFinalize(System.java:1270)
	at java.lang.ref.Finalizer.runFinalizer(Finalizer.java:98)
	at java.lang.ref.Finalizer.access$100(Finalizer.java:34)
	at java.lang.ref.Finalizer$FinalizerThread.run(Finalizer.java:213)
```