### PR TITLE
Generic JSON encoder for case-classes

### DIFF
--- a/docs/src/main/tut/04_library_scala.md
+++ b/docs/src/main/tut/04_library_scala.md
@@ -153,9 +153,6 @@ import org.apache.spark.SparkContext
 case class Foo(a: Int, b: String)
 
 object ComplexRootArgFn extends MistFn {
-
-  implicit val fooExt: RootExtractor[Foo] = encoding.generic.extractor[Foo]
-
   // expected input is json:
   //  {
   //    "a": 42,

--- a/docs/src/main/tut/04_library_scala.md
+++ b/docs/src/main/tut/04_library_scala.md
@@ -296,6 +296,7 @@ It supports:
 - Unit
 - primitives: Short, Int, Long, Float, String, Double, Boolean
 - collections: Array, Seq, Map
+- Case classes
 - experimental: DataFrame, DataSet - *Warning* - return them only if you sure that they are small, otherwise it will lead to `OutOfMemory`
   ```scala
   import mist.api.encoding.spark._
@@ -329,20 +330,6 @@ import mist.api.encoding.JsEncoder
 
 class Foo(val a: Int, val b: String)
 val fooEnc: JsEncoder[Foo] = JsEncoder(foo => JsMap("a" -> foo.a.js, "b" -> foo.b.js))
-```
-
-Also it's possible to automatically derive an encoder for case classes:
-```tut:silent
-import mist.api._
-import mist.api.encoding
-import mist.api.encoding._
-import mist.api.encoding.defaults._
-
-case class Bar(a: Int, b: String)
-case class Foo(x: Int, foos: Seq[Bar])
-
-implicit val barEnc: JsEncoder[Bar] = encoding.generic.encoder[Bar]
-implicit val fooEnc: JsEncoder[Foo] = encoding.generic.encoder[Foo]
 ```
 
 #### Validation

--- a/mist-lib/src/main/scala/mist/api/encoding/JsEncoder.scala
+++ b/mist-lib/src/main/scala/mist/api/encoding/JsEncoder.scala
@@ -1,6 +1,7 @@
 package mist.api.encoding
 
 import mist.api.data._
+import shadedshapeless.Lazy
 
 import scala.annotation.implicitNotFound
 
@@ -36,6 +37,8 @@ trait defaultEncoders {
     case None => JsNull
   }
   implicit def mapEnc[A](implicit enc: JsEncoder[A]): JsEncoder[Map[String, A]] = JsEncoder(m => JsMap(m.mapValues(enc.apply)))
+
+  implicit def productEnc[A <: Product](implicit enc: Lazy[ObjectEncoder[A]]): JsEncoder[A] = JsEncoder(enc.value.apply)
 }
 
 object defaultEncoders extends defaultEncoders

--- a/mist-lib/src/main/scala/mist/api/encoding/JsExtractor.scala
+++ b/mist-lib/src/main/scala/mist/api/encoding/JsExtractor.scala
@@ -2,6 +2,7 @@ package mist.api.encoding
 
 import mist.api._
 import mist.api.data._
+import shadedshapeless.Lazy
 
 import scala.annotation.implicitNotFound
 import scala.reflect.ClassTag
@@ -134,6 +135,12 @@ trait defaultExtractors {
 
     case value => Failed.invalidType(s"Map[String, ${ext.`type`}]", value.toString)
   }
+
+  implicit def productExtWithDefaults[A <: Product](implicit
+      ext: Lazy[ObjectExtractor[A]],
+      patcher: Lazy[DefaultsPatcher[A]]
+  ): RootExtractor[A] =
+    RootExtractor[A](ext.value.`type`)(js => ext.value.apply(patcher.value.apply(js)))
 }
 
 


### PR DESCRIPTION
Allows conversion of any Scala case class and tuples to/from JSON by importing  `mist.api.encoding.defaults._`. Makes it unnecessary to create encoders for case classes.

Encoders for specific classes (case classes) will continue to take precedence over this generic encoder and extractor. Hence the ability to create specific encoders remains unaffected, and existing code will not break.

Derived from the examples in the documentation. I can't build and test mist locally beyond compilation because of time constrains.

I'm not sure if the import of `shadedshapeless.Lazy` is necessary.

Also, feel free to reject this pull request if there is a reason why this hasn't been implemented yet.